### PR TITLE
fix packet number overflow

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -188,7 +188,7 @@ local function _send_packet(self, req, size)
 
     -- print("packet no: ", self.packet_no)
 
-    local packet = _set_byte3(size) .. strchar(self.packet_no) .. req
+    local packet = _set_byte3(size) .. strchar(bit.band(self.packet_no, 255)) .. req
 
     -- print("sending packet: ", _dump(packet))
 

--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -188,7 +188,7 @@ local function _send_packet(self, req, size)
 
     -- print("packet no: ", self.packet_no)
 
-    local packet = _set_byte3(size) .. strchar(bit.band(self.packet_no, 255)) .. req
+    local packet = _set_byte3(size) .. strchar(band(self.packet_no, 255)) .. req
 
     -- print("sending packet: ", _dump(packet))
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1283,19 +1283,6 @@ GET /t
             for i = 1, 260 do
                 db:query("insert into cats(name) values (\'abc\')")
             end
-            db:close()
-
-
-            local ok, err, errno, sqlstate = db:connect({
-                path = "$TEST_NGINX_MYSQL_PATH",
-                database = "ngx_test",
-                user = "ngx_test",
-                password = "ngx_test",
-                pool = "my_pool"})
-            if not ok then
-                ngx.say("failed to connect: ", err, ": ", errno, " ", sqlstate)
-                return
-            end
 
             --according to the MySQL protocol, make packet number be equal to 255
             --packet number = header(1) + field(M) + eof(1) + row(N) + eof(1)

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1274,19 +1274,25 @@ GET /t
                 return
             end
 
-            --generate test data
-            local res, err, errno, sqlstate = db:query("create table if not exists cats (id serial primary key, name varchar(5))")
+            -- generate test data
+            local res, err, errno, sqlstate = db:query("drop table if exists cats")
             if not res then
                 ngx.say("bad result: ", err, ": ", errno, ": ", sqlstate, ".")
                 return
             end
+            res, err, errno, sqlstate = db:query("create table cats (id serial primary key, name varchar(5))")
+            if not res then
+                ngx.say("bad result: ", err, ": ", errno, ": ", sqlstate, ".")
+                return
+            end
+
             for i = 1, 260 do
                 db:query("insert into cats(name) values (\'abc\')")
             end
 
-            --according to the MySQL protocol, make packet number be equal to 255
-            --packet number = header(1) + field(M) + eof(1) + row(N) + eof(1)
-            --the following sql packet number is: 1 + 1 + 1 + 251 + 1 = 255
+            -- according to the MySQL protocol, make packet number be equal to 255
+            -- packet number = header(1) + field(M) + eof(1) + row(N) + eof(1)
+            -- the following sql packet number is: 1 + 1 + 1 + 251 + 1 = 255
             local res, err, errno, sqlstate = db:query("select id from cats limit 251")
             db:close()
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1250,6 +1250,8 @@ GET /t
 --- no_error_log
 [error]
 
+
+
 === TEST 19: fix packet number overflow
 --- http_config eval: $::HttpConfig
 --- config

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1256,7 +1256,7 @@ GET /t
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
-        content_by_lua '
+        content_by_lua_block {
             local mysql = require "resty.mysql"
             local db = mysql:new()
 
@@ -1311,7 +1311,7 @@ GET /t
                 return
             end
             ngx.say("success")
-        ';
+        }
     }
 --- request
 GET /t

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1301,6 +1301,7 @@ GET /t
             --packet number = header(1) + field(M) + eof(1) + row(N) + eof(1)
             --the following sql packet number is: 1 + 1 + 1 + 251 + 1 = 255
             local res, err, errno, sqlstate = db:query("select id from cats limit 251")
+            db:close()
 
             if not res then
                 ngx.say("bad result: ", err, ": ", errno, ": ", sqlstate, ".")

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1297,7 +1297,7 @@ GET /t
 
             --according to the MySQL protocol, make packet number be equal to 255
             --packet number = header(1) + field(M) + eof(1) + row(N) + eof(1)
-            --the following sql's packet number is: 1 + 1 + 1 + 251 + 1 = 255
+            --the following sql packet number is: 1 + 1 + 1 + 251 + 1 = 255
             local res, err, errno, sqlstate = db:query("select id from cats limit 251")
 
             if not res then

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1250,3 +1250,70 @@ GET /t
 --- no_error_log
 [error]
 
+=== TEST 19: fix packet number overflow
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local mysql = require "resty.mysql"
+            local db = mysql:new()
+
+            db:set_timeout(1000) -- 1 sec
+
+            local ok, err, errno, sqlstate = db:connect({
+                path = "$TEST_NGINX_MYSQL_PATH",
+                database = "ngx_test",
+                user = "ngx_test",
+                password = "ngx_test",
+                pool = "my_pool"})
+
+            if not ok then
+                ngx.say("failed to connect: ", err, ": ", errno, " ", sqlstate)
+                return
+            end
+
+            --generate test data
+            local res, err, errno, sqlstate = db:query("create table if not exists cats (id serial primary key, name varchar(5))")
+            if not res then
+                ngx.say("bad result: ", err, ": ", errno, ": ", sqlstate, ".")
+                return
+            end
+            for i = 1, 260 do
+                db:query("insert into cats(name) values (\'abc\')")
+            end
+            db:close()
+
+
+            local ok, err, errno, sqlstate = db:connect({
+                path = "$TEST_NGINX_MYSQL_PATH",
+                database = "ngx_test",
+                user = "ngx_test",
+                password = "ngx_test",
+                pool = "my_pool"})
+            if not ok then
+                ngx.say("failed to connect: ", err, ": ", errno, " ", sqlstate)
+                return
+            end
+
+            --according to the MySQL protocol, make packet number be equal to 255
+            --packet number = header(1) + field(M) + eof(1) + row(N) + eof(1)
+            --the following sql's packet number is: 1 + 1 + 1 + 251 + 1 = 255
+            local res, err, errno, sqlstate = db:query("select id from cats limit 251")
+
+            if not res then
+                ngx.say("bad result: ", err, ": ", errno, ": ", sqlstate, ".")
+                return
+            end
+            if #res ~= 251 then
+                ngx.say("bad result, not got 251 rows")
+                return
+            end
+            ngx.say("success")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+success
+--- no_error_log
+[error]


### PR DESCRIPTION
user bug report in google group : https://groups.google.com/forum/#!topic/openresty/j3a-x75x0D0

the packet number is uchar type, from 0 to 255.
if overflow, the result should be equal with `(uchar) net->pkt_nr++`, which is from MySQL source code line 316 in function `my_net_write` : https://github.com/mysql/mysql-server/blob/71f48ab393bce80a59e5a2e498cd1f46f6b43f9a/sql/net_serv.cc