### PR TITLE
convert to number when it is decimal

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -108,12 +108,13 @@ local mt = { __index = _M }
 
 
 -- mysql field value type converters
-local converters = new_tab(0, 8)
+local converters = new_tab(0, 9)
 
 for i = 0x01, 0x05 do
     -- tiny, short, long, float, double
     converters[i] = tonumber
 end
+converters[0x00] = tonumber  -- decimal
 -- converters[0x08] = tonumber  -- long long
 converters[0x09] = tonumber  -- int24
 converters[0x0d] = tonumber  -- year


### PR DESCRIPTION
When I query some decimal data from DB, it is not converted to number because it is 	FIELD_TYPE_DECIMAL(0x00). Though FIELD_TYPE_NEWDECIMAL (0xF6, new in MYSQL 5.0) is used, some DB is still using FIELD_TYPE_DECIMAL. 