### PR TITLE
feature: support pass table to send_query

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -286,6 +286,8 @@ send_query
 
 Sends the query to the remote MySQL server without waiting for its replies.
 
+The argument query can be a string or a (nested) Lua table holding string fragments.
+
 Returns the bytes successfully sent out in success and otherwise returns `nil` and a string describing the error.
 
 You should use the [read_result](#read_result) method to read the MySQL replies afterwards.


### PR DESCRIPTION
## problem
Luajit is poor at creating a lot of similar strings due to hash collisions. The discussion can be seen in [Github: Reduce string hash collisions](https://github.com/LuaJIT/LuaJIT/issues/168).
So it consumes a lot cpu when construct sql statements dynamically. 
This problem has already been asked on openresty-cn's google group:
* [火焰图显示lj_str_new调用过多，请大家帮我找一下原因](https://groups.google.com/forum/#!topic/openresty/zD1N_S6ibUY)
* [luajit在处理某些字符串场景时出现性能问题](https://groups.google.com/forum/#!msg/openresty/guVFrMTVD8U/0-tbM7BCAQAJ)

## solution
Fortunately, cosocket's send method can receive a table of strings and it will handle it in C land. A temporary solution is to avoid string creation in lua and pass the table of sql segments into cosocket's send method just like resty-redis does.

## result
In my application, the performance(QPS) improves 50%. 

The flame graph proves that the lj_new_str is no longger the bottleneck:
Before:
![before](/yanxurui/nq/raw/master/benchmark/pull_lua.svg?sanitize=true)
After:
![after](/yanxurui/nq/raw/master/benchmark/pull_lua2.svg?sanitize=true)
I hopes this can help others.