### PR TITLE
fix: strip 0x00 from the end of a string

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -178,7 +178,7 @@ local function _from_cstring(data, i)
         return nil, nil
     end
 
-    return sub(data, i, last), last + 1
+    return sub(data, i, last - 1), last + 1
 end
 
 

--- a/t/compact_arrays.t
+++ b/t/compact_arrays.t
@@ -79,7 +79,7 @@ __DATA__
 --- request
 GET /t
 --- response_body_like chop
-^connected to mysql \d\.\S+\.
+^connected to mysql \d\.[^\s\x00]+\.
 sent 30 bytes\.
 result: (?:{"insert_id":0,"server_status":2,"warning_count":[01],"affected_rows":0}|{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]})$
 --- no_error_log

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -129,7 +129,7 @@ GET /t
 --- request
 GET /t
 --- response_body_like
-connected to mysql \d\.\S+
+connected to mysql \d\.[^\s\x00]+
 --- no_error_log
 [error]
 
@@ -184,7 +184,7 @@ connected to mysql \d\.\S+
 --- request
 GET /t
 --- response_body_like chop
-^connected to mysql \d\.\S+\.
+^connected to mysql \d\.[^\s\x00]+\.
 sent 30 bytes\.
 result: \{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]\}$
 --- no_error_log
@@ -242,7 +242,7 @@ result: \{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]
 --- request
 GET /t
 --- response_body_like chop
-^connected to mysql \d\.\S+\.
+^connected to mysql \d\.[^\s\x00]+\.
 sent 12 bytes\.
 bad result: You have an error in your SQL syntax; check the manual that corresponds to your (?:MySQL|MariaDB) server version for the right syntax to use near 'bad SQL' at line 1: 1064: 42000\.$
 --- no_error_log
@@ -882,7 +882,7 @@ qr/lua tcp socket keepalive create connection pool for key "ngx_test:ngx_test:[^
 --- request
 GET /t
 --- response_body_like chop
-^connected to mysql \d\.\S+\.
+^connected to mysql \d\.[^\s\x00]+\.
 sent 30 bytes\.
 result: (?:\{"insert_id":0,"server_status":2,"warning_count":1,"affected_rows":0}|{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]\})$
 --- no_error_log

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -81,7 +81,7 @@ __DATA__
 --- request
 GET /t
 --- response_body_like chop
-^connected to mysql \d\.\S+\.
+^connected to mysql \d\.[^\s\x00]+\.
 sent 30 bytes\.
 result: \{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]\}$
 --- no_error_log
@@ -143,7 +143,7 @@ result: \{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]
 --- request
 GET /t
 --- response_body_like chop
-^connected to mysql \d\.\S+\.
+^connected to mysql \d\.[^\s\x00]+\.
 sent 30 bytes\.
 result: \{"affected_rows":0,"insert_id":0,"server_status":2,"warning_count":[01]\}$
 --- no_error_log


### PR DESCRIPTION
`local str, pos = _from_cstring(data, pos)`

0x00 in `str` probably not needed. 