### PR TITLE
Add a metatable with ordered column names

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -927,6 +927,8 @@ local function read_result(self, est_nrows)
     end
 
     self.state = STATE_CONNECTED
+    
+    setmetatable(rows,cols)
 
     return rows
 end


### PR DESCRIPTION
To allow column order reconstruction after a query.