### PR TITLE
add support for json column type

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -1,5 +1,6 @@
 -- Copyright (C) Yichun Zhang (agentzh)
 
+local json = require 'cjson'
 
 local bit = require "bit"
 local sub = string.sub
@@ -35,6 +36,15 @@ end
 local ok, new_tab = pcall(require, "table.new")
 if not ok then
     new_tab = function (narr, nrec) return {} end
+end
+
+local function tojson(value)
+    if not value then
+        return
+    end 
+    local result = nil 
+    pcall(function (data) result = json.decode(data) end, value)    
+    return result
 end
 
 
@@ -119,7 +129,7 @@ converters[0x00] = tonumber  -- decimal
 converters[0x09] = tonumber  -- int24
 converters[0x0d] = tonumber  -- year
 converters[0xf6] = tonumber  -- newdecimal
-
+converters[0xf5] = tojson    -- tojson
 
 local function _get_byte2(data, i)
     local a, b = strbyte(data, i, i + 1)


### PR DESCRIPTION
After mysql 5.7 published, mysql already supported with json column type, but lua-resty-mysql component not, it maked json type as string.  When existing json column type in result for querying,  it needed to convert every json column field in application layer. it is not convenient.