### PR TITLE
Ensure packet_no is not nil before proceeding

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -371,6 +371,10 @@ end
 local function _send_packet(self, req, size)
     local sock = self.sock
 
+    if self.packet_no == nil then
+        self.packet_no = 0
+    end
+
     self.packet_no = self.packet_no + 1
 
     -- print("packet no: ", self.packet_no)

--- a/t/bug.t
+++ b/t/bug.t
@@ -77,3 +77,18 @@ __DATA__
 Rows matched: 1  Changed: 1  Warnings: 0
 --- no_error_log
 [error]
+
+
+
+=== TEST 2: ensure packet_no is not nil before proceeding (gitub #141)
+--- server_config
+        content_by_lua_block {
+            local mysql = require "resty.mysql"
+
+            local ok, err = mysql:close()
+            ngx.say("mysql connection closed")
+        }
+--- response_body_like
+mysql connection closed
+--- no_error_log
+[error]


### PR DESCRIPTION
Fixes error: `2023/02/11 23:37:58 [error] 21157#21157: *1 lua entry thread aborted: runtime error: /usr/local/openresty/lualib/resty/mysql.lua:375: attempt to perform arithmetic on field 'packet_no' (a nil value)`

Sets packet_no to zero if it is nil before proceeding