### PR TITLE
mysql driver doesn't handle well server side query timeout (Query execution was interrupted)

### DIFF
--- a/lib/resty/mysql.lua
+++ b/lib/resty/mysql.lua
@@ -1391,6 +1391,12 @@ local function read_result(self, est_nrows)
             break
         end
 
+        if typ == RESP_ERR then
+            self.state = STATE_CONNECTED
+            local errno, msg, sqlstate = _parse_err_packet(packet)
+            return nil, msg, errno, sqlstate
+        end
+
         local row = _parse_row_data_packet(packet, cols, compact)
         i = i + 1
         rows[i] = row


### PR DESCRIPTION
mysql driver doesn't handle well server side query timeout (Query execution was interrupted)

in case we set in the mysql query time limit which is low than executed queries like:

SET GLOBAL MAX_EXECUTION_TIME=1; 
the driver doesn't handle well the error:

1. doesn't parse the error well

2. doesn't report it well

3. will cause connection close due to timeout on the rows _recv_packet() - because the state doesn't enable us to setkeepalive on it.


solution:

in read rows loop we should handle the error, report it, and keep the connection state connected.